### PR TITLE
Add (optional) feature to download and extract dataset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,16 @@ exclude = [
     "data_sets/*",
 ]
 
+[features]
+default = []
+download = ["reqwest", "flate2"]
+
 [dependencies]
 byteorder = "1.0.0"
+
+# Used to download datasets
+reqwest = {version = "0.8.8", optional = true}
+flate2 = {version = "1.0.2", optional = true, features = ["rust_backend"], default-features = false}
 
 [dev-dependencies]
 rulinalg = "0.4.1"

--- a/src/download.rs
+++ b/src/download.rs
@@ -1,0 +1,102 @@
+#![cfg(feature = "download")]
+
+extern crate flate2;
+extern crate reqwest;
+
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::{fs, io};
+
+const BASE_URL: &str = "http://yann.lecun.com/exdb/mnist";
+const ARCHIVE_TRAIN_IMAGES: &str = "train-images-idx3-ubyte.gz";
+const ARCHIVE_TRAIN_LABELS: &str = "train-labels-idx1-ubyte.gz";
+const ARCHIVE_TEST_IMAGES: &str = "t10k-images-idx3-ubyte.gz";
+const ARCHIVE_TEST_LABELS: &str = "t10k-labels-idx1-ubyte.gz";
+const ARCHIVES_TO_DOWNLOAD: &[&str] = &[
+    ARCHIVE_TRAIN_IMAGES,
+    ARCHIVE_TRAIN_LABELS,
+    ARCHIVE_TEST_IMAGES,
+    ARCHIVE_TEST_LABELS,
+];
+
+pub(super) fn download_and_extract(base_path: &str) -> Result<(), String> {
+    let download_dir = PathBuf::from(base_path);
+    if !download_dir.exists() {
+        println!(
+            "Download directory {} does not exists. Creating....",
+            download_dir.display()
+        );
+        fs::create_dir(&download_dir).or_else(|e| {
+            Err(format!(
+                "Failed to create directory {:?}: {:?}",
+                download_dir, e
+            ))
+        })?;
+    }
+    for archive in ARCHIVES_TO_DOWNLOAD {
+        println!("Attempting to download and extract {}...", archive);
+        download(&archive, &download_dir)?;
+        extract(&archive, &download_dir)?;
+    }
+    Ok(())
+}
+
+fn download(archive: &str, download_dir: &Path) -> Result<(), String> {
+    let url = format!("{}/{}", BASE_URL, archive);
+    let file_name = download_dir.join(&archive);
+    if file_name.exists() {
+        println!(
+            "  File {:?} already exists, skipping downloading.",
+            file_name
+        );
+    } else {
+        println!("  Downloading {} to {:?}...", url, download_dir);
+        let f = fs::File::create(&file_name)
+            .or_else(|e| Err(format!("Failed to create file {:?}: {:?}", file_name, e)))?;
+        let mut writer = io::BufWriter::new(f);
+        let mut response =
+            reqwest::get(&url).or_else(|e| Err(format!("Failed to download {:?}: {:?}", url, e)))?;
+        let _ = io::copy(&mut response, &mut writer).or_else(|e| {
+            Err(format!(
+                "Failed to to write to file {:?}: {:?}",
+                file_name, e
+            ))
+        })?;
+        println!("  Downloading or {} to {:?} done!", archive, download_dir);
+    }
+    Ok(())
+}
+
+fn extract(archive_name: &str, download_dir: &Path) -> Result<(), String> {
+    let archive = download_dir.join(&archive_name);
+    let extract_to = download_dir.join(&archive_name.replace(".gz", ""));
+    if extract_to.exists() {
+        println!(
+            "  Extracted file {:?} already exists, skipping extraction.",
+            extract_to
+        );
+    } else {
+        println!("Extracting archive {:?} to {:?}...", archive, extract_to);
+        let file_in = fs::File::open(&archive)
+            .or_else(|e| Err(format!("Failed to open archive {:?}: {:?}", archive, e)))?;
+        let file_in = io::BufReader::new(file_in);
+        let file_out = fs::File::create(&extract_to).or_else(|e| {
+            Err(format!(
+                "  Failed to create extracted file {:?}: {:?}",
+                archive, e
+            ))
+        })?;
+        let mut file_out = io::BufWriter::new(file_out);
+        let mut gz = flate2::bufread::GzDecoder::new(file_in);
+        let mut v: Vec<u8> = Vec::with_capacity(10 * 1024 * 1024);
+        gz.read_to_end(&mut v)
+            .or_else(|e| Err(format!("Failed to extract archive {:?}: {:?}", archive, e)))?;
+        file_out.write_all(&v).or_else(|e| {
+            Err(format!(
+                "Failed to write extracted data to {:?}: {:?}",
+                archive, e
+            ))
+        })?;
+    }
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,6 +359,16 @@ impl<'a> MnistBuilder<'a> {
     /// # Panics
     /// If `trn_len + val_len + tst_len > 70,000`.
     pub fn finalize(&self) -> Mnist {
+        if self.download_and_extract {
+            #[cfg(feature = "download")]
+            download::download_and_extract(&self.base_path).unwrap();
+            #[cfg(not(feature = "download"))]
+            {
+                println!("WARNING: Download disabled.");
+                println!("         Please use the mnist crate's 'download' feature to enable.");
+            }
+        }
+
         let &MnistBuilder { trn_len, val_len, tst_len, .. } = self;
         let (trn_len, val_len, tst_len) = (trn_len as usize, val_len as usize, tst_len as usize);
         let total_length = trn_len + val_len + tst_len;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@
 
 extern crate byteorder;
 
+mod download;
 mod tests;
 
 use byteorder::{BigEndian, ReadBytesExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,7 @@ pub struct MnistBuilder<'a> {
     trn_lbl_filename: &'a str,
     tst_img_filename: &'a str,
     tst_lbl_filename: &'a str,
+    download_and_extract: bool,
 }
 
 impl<'a> MnistBuilder<'a> {
@@ -177,6 +178,7 @@ impl<'a> MnistBuilder<'a> {
             trn_lbl_filename: TRN_LBL_FILENAME,
             tst_img_filename: TST_IMG_FILENAME,
             tst_lbl_filename: TST_LBL_FILENAME,
+            download_and_extract: false,
         }
     }
 
@@ -317,6 +319,29 @@ impl<'a> MnistBuilder<'a> {
     /// ```
     pub fn test_labels_filename(&mut self, tst_lbl_filename: &'a str) -> &mut MnistBuilder<'a> {
         self.tst_lbl_filename = tst_lbl_filename;
+        self
+    }
+
+    // #[cfg(feature = "download")]
+    /// Download and extract MNIST dataset if not present.
+    ///
+    /// If archives are already present, they will not be downloaded.
+    ///
+    /// If datasets are already present, they will not be extracted.
+    ///
+    /// Note that this requires the 'download' feature to be enabled
+    /// (disabled by default).
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// # use mnist::MnistBuilder;
+    /// let mnist = MnistBuilder::new()
+    ///     .download_and_extract()
+    ///     .finalize();
+    /// ```
+    pub fn download_and_extract(&mut self) -> &mut MnistBuilder<'a> {
+        self.download_and_extract = true;
+
         self
     }
 


### PR DESCRIPTION
This PR adds a `download` cargo feature that enables downloading and extracting the MNIST dataset.

To do so, use the `download_and_extract()` method on `MnistBuilder` and activate the cargo feature when compiling with `--feature download`.

If the feature is not explicitly enabled, a warning is printed if `download_and_extract()` is used.