### PR TITLE
Normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ fn main() {
         .test_set_length(10_000)
         .finalize();
 
+    // Call `normalize()` on the return value of `finalize()` to get
+    // Vec<f32> normalized values for the pixels instead of grayscale (bytes):
+    // let NormalizedMnist { trn_img, trn_lbl, .. } = MnistBuilder::new()
+    //     .label_format_digit()
+    //     .training_set_length(trn_size)
+    //     .validation_set_length(10_000)
+    //     .test_set_length(10_000)
+    //     .finalize()
+    //     .normalize();
+
     // Get the label of the first digit.
     let first_label = trn_lbl[0];
     println!("The first digit is a {}.", first_label);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -420,6 +420,59 @@ impl<'a> MnistBuilder<'a> {
     }
 }
 
+impl Mnist {
+    /// Create a `NormalizedMnist` by consuming an `Mnist`.
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// # use mnist::{MnistBuilder, NormalizedMnist};
+    /// let normalized_mnist: NormalizedMnist = MnistBuilder::new()
+    ///    .finalize()
+    ///    .normalize();
+    /// ```
+    pub fn normalize(self) -> NormalizedMnist {
+        NormalizedMnist::new(self)
+    }
+}
+
+#[derive(Debug)]
+/// Struct containing (normalized) image and label vectors for the training, validation, and test sets.
+pub struct NormalizedMnist {
+    pub trn_img: Vec<f32>,
+    pub trn_lbl: Vec<u8>,
+    pub val_img: Vec<f32>,
+    pub val_lbl: Vec<u8>,
+    pub tst_img: Vec<f32>,
+    pub tst_lbl: Vec<u8>,
+}
+
+impl NormalizedMnist {
+    /// Create a `NormalizedMnist` by consuming an `Mnist`.
+    ///
+    /// # Examples
+    /// ```rust,no_run
+    /// # use mnist::{MnistBuilder, NormalizedMnist};
+    /// let normalized_mnist: NormalizedMnist = MnistBuilder::new()
+    ///    .finalize()
+    ///    .normalize();
+    /// ```
+    pub fn new(mnist: Mnist) -> NormalizedMnist {
+        NormalizedMnist {
+            trn_img: normalize_vector(&mnist.trn_img),
+            trn_lbl: mnist.trn_lbl,
+            val_img: normalize_vector(&mnist.val_img),
+            val_lbl: mnist.val_lbl,
+            tst_img: normalize_vector(&mnist.tst_img),
+            tst_lbl: mnist.tst_lbl,
+        }
+    }
+}
+
+/// Normalize a vector of bytes as 32-bit floats.
+fn normalize_vector(v: &Vec<u8>) -> Vec<f32> {
+    v.iter().map(|&pixel| (pixel as f32) / 255.0_f32).collect()
+}
+
 #[derive(Debug, PartialEq)]
 enum LabelFormat {
     Digit,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -195,3 +195,26 @@ fn test_12() {
         .test_labels_filename("test")
         .finalize();
 }
+
+#[test]
+fn normalize_vector() {
+    use super::normalize_vector;
+
+    let v: Vec<u8> = vec![0, 1, 2, 127, 128, 129, 254, 255];
+    let normalized_v: Vec<f32> = normalize_vector(&v);
+    let expected: Vec<f32> = vec![
+        0.0,
+        0.00392157,
+        0.00784314,
+        0.49803922,
+        0.50196078,
+        0.50588235,
+        0.99607843,
+        1.0,
+    ];
+
+    expected
+        .iter()
+        .zip(normalized_v.iter())
+        .for_each(|(value, expected)| assert!((value - expected).abs() < 1.0e-6));
+}


### PR DESCRIPTION
Add a `normalize()` method to `Mnist` that consumes it and return similar structure with pixel values as normalized f32.