### PR TITLE
Add support for Fashion MNIST dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 target2
 Cargo.lock
+data/fashion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [
     "data/*",
     "data_sets/*",
 ]
+edition = "2018"
 
 [features]
 default = []
@@ -21,8 +22,10 @@ download = ["reqwest", "flate2"]
 byteorder = "1.0.0"
 
 # Used to download datasets
-reqwest = {version = "0.8.8", optional = true}
+reqwest = {version = "0.10", optional = true, features = ["blocking"]}
 flate2 = {version = "1.0.2", optional = true, features = ["rust_backend"], default-features = false}
 
 [dev-dependencies]
 rulinalg = "0.4.1"
+# minifb is used to visualize datasets in a pop-up window
+minifb = "0.17"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ drop-in replacement dataset for the original MNIST set, but typically poses a mo
 
 An example of downloading this dataset may be found by running: 
 ```sh
-$ cargo --release --features download --example fashion_mnist
+$ cargo run --features download --example fashion_mnist
 ```
 This example uses the [minifb](https://github.com/emoon/rust_minifb) library to display the parsed images,
 and may require the installation of certain dependencies. On an Ubuntu-like system, this may be done via:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MNIST
-A crate for parsing the [MNIST](http://yann.lecun.com/exdb/mnist/) data set into vectors to be
+A crate for parsing the [MNIST](http://yann.lecun.com/exdb/mnist/) and [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) data set into vectors to be
 used by Rust programs.
 
 * [Crate](https://crates.io/crates/mnist)
@@ -54,4 +54,18 @@ fn main() {
         .apply(&|p| (p * 10.0).round() / 10.0);
     println!("The image looks like... \n{}", first_image);
 }
+```
+
+## Fashion MNIST
+The Fasion MNIST [dataset](https://github.com/zalandoresearch/fashion-mnist) offers a similarly-formatted 
+drop-in replacement dataset for the original MNIST set, but typically poses a more difficult classification challenge that handwritten numbers. 
+
+An example of downloading this dataset may be found by running: 
+```sh
+$ cargo --release --features download --example fashion_mnist
+```
+This example uses the [minifb](https://github.com/emoon/rust_minifb) library to display the parsed images,
+and may require the installation of certain dependencies. On an Ubuntu-like system, this may be done via:
+```sh
+$ sudo apt install libxkbcommon-dev libwayland-cursor0 libwayland-dev
 ```

--- a/examples/fashion_mnist.rs
+++ b/examples/fashion_mnist.rs
@@ -1,0 +1,79 @@
+extern crate minifb;
+use minifb::{Key, ScaleMode, Window, WindowOptions};
+
+extern crate mnist;
+use mnist::*;
+
+// $ cargo run --features download --example fashion_mnist
+// minifb requires `$ sudo apt install libxkbcommon-dev libwayland-cursor0 libwayland-dev`
+
+fn main() {
+    let (trn_size, rows, cols) = (50_000, 28, 28);
+
+    // Deconstruct the returned Mnist struct.
+    let Mnist {
+        trn_img, trn_lbl, ..
+    } = MnistBuilder::new()
+        .base_path("data/fashion/") // Comment out this and `use_fashion_data()` to run on the original MNIST
+        .label_format_digit()
+        .training_set_length(trn_size)
+        .validation_set_length(10_000)
+        .test_set_length(10_000)
+        .download_and_extract()
+        .use_fashion_data() // Commnent out this and the changed `.base_path()` to run on the original MNIST
+        .finalize();
+
+    let item_num = 0;
+    return_item_description_from_number(trn_lbl[item_num]);
+    display_img(trn_img[item_num * 784..item_num * 784 + 784].to_vec());
+}
+
+fn display_img(input: Vec<u8>) {
+    // println!("img_vec: {:?}",img_vec);
+    let mut buffer: Vec<u32> = Vec::with_capacity(28 * 28);
+    for px in 0..784 {
+        let temp: [u8; 4] = [input[px], input[px], input[px], 255u8];
+        // println!("temp: {:?}",temp);
+        buffer.push(u32::from_le_bytes(temp));
+    }
+
+    let (window_width, window_height) = (600, 600);
+    let mut window = Window::new(
+        "Test - ESC to exit",
+        window_width,
+        window_height,
+        WindowOptions {
+            resize: true,
+            scale_mode: ScaleMode::Center,
+            ..WindowOptions::default()
+        },
+    )
+    .unwrap_or_else(|e| {
+        panic!("{}", e);
+    });
+
+    // Limit to max ~60 fps update rate
+    window.limit_update_rate(Some(std::time::Duration::from_micros(16600)));
+
+    while window.is_open() && !window.is_key_down(Key::Escape) && !window.is_key_down(Key::Q) {
+        // We unwrap here as we want this code to exit if it fails. Real applications may want to handle this in a different way
+        window.update_with_buffer(&buffer, 28, 28).unwrap();
+    }
+}
+
+fn return_item_description_from_number(val: u8) {
+    let description = match val {
+        0 => "T-shirt/top",
+        1 => "Trouser",
+        2 => "Pullover",
+        3 => "Dress",
+        4 => "Coat",
+        5 => "Sandal",
+        6 => "Shirt",
+        7 => "Sneaker",
+        8 => "Bag",
+        9 => "Ankle boot",
+        _ => panic!("An unrecognized label was used..."),
+    };
+    println!("Based on the '{}' label, this image should be a: {} ", val, description);
+}

--- a/src/download.rs
+++ b/src/download.rs
@@ -27,7 +27,7 @@ pub(super) fn download_and_extract(base_path: &str, use_fashion_data: bool) -> R
             "Download directory {} does not exists. Creating....",
             download_dir.display()
         );
-        fs::create_dir(&download_dir).or_else(|e| {
+        fs::create_dir_all(&download_dir).or_else(|e| {
             Err(format!(
                 "Failed to create directory {:?}: {:?}",
                 download_dir, e

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -2,15 +2,17 @@
 
 extern crate rulinalg;
 
-use super::*;
 use self::rulinalg::matrix::{BaseMatrix, BaseMatrixMut, Matrix};
+use super::*;
 
 #[test]
 fn test_example() {
     let (trn_size, rows, cols) = (50_000, 28, 28);
 
     // Deconstruct the returned Mnist struct.
-    let Mnist { trn_img, trn_lbl, .. } = MnistBuilder::new()
+    let Mnist {
+        trn_img, trn_lbl, ..
+    } = MnistBuilder::new()
         .label_format_digit()
         .training_set_length(trn_size)
         .validation_set_length(10_000)
@@ -33,7 +35,8 @@ fn test_example() {
     let trn_img: Matrix<f32> = trn_img.try_into().unwrap() / 255.0;
 
     // Get the image of the first digit and round the values to the nearest tenth.
-    let first_image = trn_img.select_rows(&row_indexes)
+    let first_image = trn_img
+        .select_rows(&row_indexes)
         .apply(&|p| (p * 10.0).round() / 10.0);
     println!("The image looks like... \n{}", first_image);
 }
@@ -75,7 +78,8 @@ fn test_01() {
 
 #[test]
 #[should_panic(
-    expected = "Total data set length (70001) greater than maximum possible length (70000).")]
+    expected = "Total data set length (70001) greater than maximum possible length (70000)."
+)]
 fn test_02() {
     let _ = MnistBuilder::new()
         .training_set_length(50_001)
@@ -86,7 +90,8 @@ fn test_02() {
 
 #[test]
 #[should_panic(
-    expected = "Total data set length (70001) greater than maximum possible length (70000).")]
+    expected = "Total data set length (70001) greater than maximum possible length (70000)."
+)]
 fn test_03() {
     let _ = MnistBuilder::new()
         .training_set_length(50_000)
@@ -97,7 +102,8 @@ fn test_03() {
 
 #[test]
 #[should_panic(
-    expected = "Total data set length (70001) greater than maximum possible length (70000).")]
+    expected = "Total data set length (70001) greater than maximum possible length (70000)."
+)]
 fn test_04() {
     let _ = MnistBuilder::new()
         .training_set_length(50_000)
@@ -108,7 +114,8 @@ fn test_04() {
 
 #[test]
 #[should_panic(
-    expected = "Total data set length (70300) greater than maximum possible length (70000).")]
+    expected = "Total data set length (70300) greater than maximum possible length (70000)."
+)]
 fn test_05() {
     let _ = MnistBuilder::new()
         .training_set_length(50_100)
@@ -142,7 +149,8 @@ fn test_06() {
 
 #[test]
 #[should_panic(
-    expected = "Total data set length (70001) greater than maximum possible length (70000).")]
+    expected = "Total data set length (70001) greater than maximum possible length (70000)."
+)]
 fn test_07() {
     let _ = MnistBuilder::new()
         .training_set_length(50_000)
@@ -153,16 +161,14 @@ fn test_07() {
 
 #[test]
 #[should_panic(
-    expected = "Unable to find path to images at \"wrong/path/train-images-idx3-ubyte\".")]
+    expected = "Unable to find path to images at \"wrong/path/train-images-idx3-ubyte\"."
+)]
 fn test_08() {
-    let _ = MnistBuilder::new()
-        .base_path("wrong/path")
-        .finalize();
+    let _ = MnistBuilder::new().base_path("wrong/path").finalize();
 }
 
 #[test]
-#[should_panic(
-    expected = "Unable to find path to images at \"data/test\".")]
+#[should_panic(expected = "Unable to find path to images at \"data/test\".")]
 fn test_09() {
     let _ = MnistBuilder::new()
         .training_images_filename("test")
@@ -170,8 +176,7 @@ fn test_09() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Unable to find path to labels at \"data/test\".")]
+#[should_panic(expected = "Unable to find path to labels at \"data/test\".")]
 fn test_10() {
     let _ = MnistBuilder::new()
         .training_labels_filename("test")
@@ -179,21 +184,15 @@ fn test_10() {
 }
 
 #[test]
-#[should_panic(
-    expected = "Unable to find path to images at \"data/test\".")]
+#[should_panic(expected = "Unable to find path to images at \"data/test\".")]
 fn test_11() {
-    let _ = MnistBuilder::new()
-        .test_images_filename("test")
-        .finalize();
+    let _ = MnistBuilder::new().test_images_filename("test").finalize();
 }
 
 #[test]
-#[should_panic(
-    expected = "Unable to find path to labels at \"data/test\".")]
+#[should_panic(expected = "Unable to find path to labels at \"data/test\".")]
 fn test_12() {
-    let _ = MnistBuilder::new()
-        .test_labels_filename("test")
-        .finalize();
+    let _ = MnistBuilder::new().test_labels_filename("test").finalize();
 }
 
 #[test]
@@ -203,14 +202,7 @@ fn normalize_vector() {
     let v: Vec<u8> = vec![0, 1, 2, 127, 128, 129, 254, 255];
     let normalized_v: Vec<f32> = normalize_vector(&v);
     let expected: Vec<f32> = vec![
-        0.0,
-        0.00392157,
-        0.00784314,
-        0.49803922,
-        0.50196078,
-        0.50588235,
-        0.99607843,
-        1.0,
+        0.0, 0.00392157, 0.00784314, 0.49803922, 0.50196078, 0.50588235, 0.99607843, 1.0,
     ];
 
     expected


### PR DESCRIPTION
@davidMcneil 

Hello,

This pull request adds initial support for the Fashion MNIST dataset, which is similarly-formatted. It includes:
- Extensions to the `download` features for downloading the FMNIST tarballs,
- Updates the library to the Rust 2018 edition
- Version updates of dependencies (notably, the `reqwest` crate has changed since async/await has shipped, although the `get()` function is still blocking)
- Adds an example that displays parsed images using the [`minifb`](https://github.com/emoon/rust_minifb) library.

All tests should still pass, and installation instructions for the dependency on the optional example are included in the README