### PR TITLE
Adds conditional flag for unix vs. Windows file metadata

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -98,7 +98,12 @@ fn download(
                 while current_size < full_size {
                     let meta = fs::metadata(file_name.clone())
                         .expect(&format!("Couldn't get metadata on {:?}", file_name));
+                    
+                    #[cfg(target_family = "unix")]
                     current_size = meta.size() as usize;
+                    #[cfg(target_family = "windows")]
+                    current_size = meta.file_size() as usize;
+                    
                     pb.set(current_size.try_into().unwrap());
                     thread::sleep_ms(10);
                 }


### PR DESCRIPTION
This is a preliminary fix for #10 by adding a conditional compilation flag for the `target_family` between `unix` and `windows`. Please don't merge until it's been verified that this actually fixes the issue on Windows (another contributor has volunteered to do that on their machine)